### PR TITLE
Make react-native and co a peerDependency instead of dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "url": "https://github.com/yeyintkoko/react-native-sms-x/issues"
   },
   "homepage": "https://github.com/yeyintkoko/react-native-sms-x#readme",
-  "dependencies": {
-    "react": "^15.3.2",
-    "react-native": "^0.36.1"
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
**Rationale**
- We don't want multiple `react-native` versions being installed inside `node_modules`